### PR TITLE
Update 2013-08-20-wcmmode-tags.md

### DIFF
--- a/_posts/acs-aem-commons/features/2013-08-20-wcmmode-tags.md
+++ b/_posts/acs-aem-commons/features/2013-08-20-wcmmode-tags.md
@@ -58,7 +58,7 @@ EL Functions available are:
 These would typically be used in a `<c:if>` tag, e.g.
 
 {% highlight jsp %}
-<c:if test="${blank properties['title'] && wcmmode:isEdit(pageContext)}">
+<c:if test="${empty properties['title'] && wcmmode:isEdit(pageContext)}">
     You probably want to populate the title in the dialog.
 </c:if>
 {% endhighlight %}


### PR DESCRIPTION
blank is not a jsp el operator, suggest replacing with empty.  It's not quite the same thing, but the simplest alternative in given the example
