### PR TITLE
Update maven.md to correct numbering and indents

### DIFF
--- a/acs-aem-commons/pages/maven.md
+++ b/acs-aem-commons/pages/maven.md
@@ -13,57 +13,57 @@ If you're using the Content Package Maven plugin, take these two easy steps:
 In the `<dependencies>` section of your _content project's pom.xml_ file, add this:
 
 {% highlight xml %}
-    <dependency>
-        <groupId>com.adobe.acs</groupId>
-        <artifactId>acs-aem-commons-content</artifactId>
-        <version>{{ site.data.acs-aem-commons.version }}</version>
-        <type>content-package</type>
-    </dependency>
+<dependency>
+    <groupId>com.adobe.acs</groupId>
+    <artifactId>acs-aem-commons-content</artifactId>
+    <version>{{ site.data.acs-aem-commons.version }}</version>
+    <type>content-package</type>
+</dependency>
 {% endhighlight %}
 
 This will include the ''full'' package. To include the ''minimal'' package, add
 
 {% highlight xml %}
-    <classifier>min</classifier>
+<classifier>min</classifier>
 {% endhighlight %}
 
 inside the `<dependency>` element.
 
-## Step 3: Add ACS AEM Common as a Sub Package
+## Step 2: Add ACS AEM Common as a Sub Package
 
 Then, (while still in the _content project's pom.xml_) within the configuration of the `content-package-maven-plugin`, add a `subPackage`:
 
 {% highlight xml %}
-    <plugin>
-        <groupId>com.day.jcr.vault</groupId>
-        <artifactId>content-package-maven-plugin</artifactId>
-        <extensions>true</extensions>
-        <configuration>
-            ...
-            <subPackages>
-                <subPackage>
-                    <groupId>com.adobe.acs</groupId>
-                    <artifactId>acs-aem-commons-content</artifactId>
-                    <filter>true</filter>
-                </subPackage>
-            </subPackages>
-            ...
-        </configuration>
-    </plugin>    
+<plugin>
+    <groupId>com.day.jcr.vault</groupId>
+    <artifactId>content-package-maven-plugin</artifactId>
+    <extensions>true</extensions>
+    <configuration>
+        ...
+        <subPackages>
+            <subPackage>
+                <groupId>com.adobe.acs</groupId>
+                <artifactId>acs-aem-commons-content</artifactId>
+                <filter>true</filter>
+            </subPackage>
+        </subPackages>
+        ...
+    </configuration>
+</plugin>    
 {% endhighlight %}
 
 
-## Step 4: Add ACS AEM Commons Bundle as a Dependency (Optional)
+## Step 3: Add ACS AEM Commons Bundle as a Dependency (Optional)
 
 In the `<dependencies>` section of the _pom.xml_ any maven projects that use ACS AEM Commons APIs (Java utils, TagLibs, etc.), add the dependency for the `acs-aem-commons-bundle` project. The `acs-aem-commons-bundle` will deployed as part of the `acs-aem-commons-content` package (above), however the dependency is required to compile your project when it uses ACS AEM Commons Java APIs.
 
 {% highlight xml %}
-    <dependency>
-        <groupId>com.adobe.acs</groupId>
-        <artifactId>acs-aem-commons-bundle</artifactId>
-        <version>{{ site.data.acs-aem-commons.version }}</version>
-        <scope>provided</scope>
-    </dependency>
+<dependency>
+    <groupId>com.adobe.acs</groupId>
+    <artifactId>acs-aem-commons-bundle</artifactId>
+    <version>{{ site.data.acs-aem-commons.version }}</version>
+    <scope>provided</scope>
+</dependency>
 {% endhighlight %}
 
 ## Video Walk-through

--- a/acs-aem-commons/pages/maven.md
+++ b/acs-aem-commons/pages/maven.md
@@ -29,7 +29,7 @@ This will include the ''full'' package. To include the ''minimal'' package, add
 
 inside the `<dependency>` element.
 
-## Step 2: Add ACS AEM Common as a Sub Package
+## Step 2: Add ACS AEM Commons as a Sub Package
 
 Then, (while still in the _content project's pom.xml_) within the configuration of the `content-package-maven-plugin`, add a `subPackage`:
 


### PR DESCRIPTION
Step 2 was missing, so I have shifted 3 and 4 up.

Code blocks on the [site](http://adobe-consulting-services.github.io/acs-aem-commons/pages/maven.html) were incorrectly indented.  It seems the MD parser was trimming the first line of the blocks.  Reduced the indent in each block to compensate for this.  Another option may be to instead use
```xml
<fenced>code</fenced>
```