### PR TITLE
updated documentation per dispatcher documentation

### DIFF
--- a/_posts/acs-aem-commons/features/2013-09-30-errorpagehandler.md
+++ b/_posts/acs-aem-commons/features/2013-09-30-errorpagehandler.md
@@ -46,7 +46,7 @@ The corresponding Error page is displayed.
 
 ## How to Use
 
-> In [AEM Dispatcher configuration](https://docs.adobe.com/docs/en/dispatcher/disp-install.html), set `DispatcherPassError` to '1'. This allows erring requests to be sent back to AEM. 
+> In [AEM Dispatcher configuration](https://docs.adobe.com/docs/en/dispatcher/disp-install.html), set `DispatcherPassError` to '0'. This allows erring requests to be sent back to AEM. 
 
 > Watch a [video on how to use the ACS AEM Commons Error Page Handler](http://aemcasts.com/aem/episode-11.html).
 


### PR DESCRIPTION
the DispatcherPassError should be set to '0' if we want the Dispatcher/AEM to handle the error, if its '1' then apache handles it.

BTW LOVE LOVE this feature. So easy to integrate into projects :+1: 