### PR TITLE
ACS AEM Tools Site: Reference github releases

### DIFF
--- a/_includes/acs-aem-tools/jumbotron.html
+++ b/_includes/acs-aem-tools/jumbotron.html
@@ -10,7 +10,7 @@
                     <p class="lead">Your job is hard enough</p>
                 </div>
 
-                <a href="https://github.com/Adobe-Consulting-Services/acs-aem-tools/releases/download/acs-aem-tools-{{ site.data.acs-aem-tools.version }}/acs-aem-tools-content-{{ site.data.acs-aem-tools.version }}.zip" class="action-btn">Download the latest release</a>
+                <a href="https://github.com/Adobe-Consulting-Services/acs-aem-tools/releases" class="action-btn">Download the latest release</a>
             
             </div>
          

--- a/_includes/acs-aem-tools/slides/intro.html
+++ b/_includes/acs-aem-tools/slides/intro.html
@@ -10,7 +10,7 @@
                     <p class="lead">Your job is hard enough</p>
                 </div>
                 
-                <a href="https://github.com/Adobe-Consulting-Services/acs-aem-tools/releases/download/acs-aem-tools-{{ site.data.acs-aem-tools.version }}/acs-aem-tools-content-{{ site.data.acs-aem-tools.version }}.zip" class="action-btn">Download the latest release</a>
+                <a href="https://github.com/Adobe-Consulting-Services/acs-aem-tools/releases" class="action-btn">Download the latest release</a>
             </div>
          
         </div>

--- a/acs-aem-tools/index.html
+++ b/acs-aem-tools/index.html
@@ -38,7 +38,7 @@ description: A set of tools whose goal is making AEM developer lives easier.
 
                 <p>
                     Download the 
-                    <a href="https://github.com/Adobe-Consulting-Services/acs-aem-tools/releases/download/acs-aem-tools-{{ site.data.acs-aem-tools.version }}/acs-aem-tools-content-{{ site.data.acs-aem-tools.version }}.zip">latest release</a>
+                    <a href="https://github.com/Adobe-Consulting-Services/acs-aem-tools/releases">latest release</a>
                     and install via Package Manager.
                     <sup id="fnref:1"><a href="#fn:1" rel="footnote">1</a></sup>
                 </p>


### PR DESCRIPTION
currently the ACS AEM tools site links directly to the "full" version of the AEM package, hiding the fact that a "min" version without external dependencies is available as well.

similar to the download link for ACS commons the ACS tools site should link to the github releases page offering both download links.