### PR TITLE
Updated documentation of Site Map Servlet

### DIFF
--- a/_posts/acs-aem-commons/features/2014-01-01-simple-sitemap.md
+++ b/_posts/acs-aem-commons/features/2014-01-01-simple-sitemap.md
@@ -40,8 +40,10 @@ Typically, you will also want to use either Resource Resolver Mappings or mod_re
     sling.servlet.resourceTypes="[myapp/components/page/home-page]"
     externalizer.domain="publish"
     include.lastmod="{Boolean}false"
-    changefreq.properties="[myChangeFreq]"
-    priority.properties="[myPriority]"
+    changefreq.properties="[myChangeFreqProperties]"
+    priority.properties="[myPriorityProperties]"
+    damassets.property="myDAMFoldersProperty"
+    damassets.types="[myDAMAllowedMIMETypes]"
     />
 {% endhighlight %}   
 
@@ -56,4 +58,10 @@ Typically, you will also want to use either Resource Resolver Mappings or mod_re
 
 * *changefreq.properties* The set of JCR property names which will contain the change frequency value. Defaults to none.
 
-* *priority.properties* The set of JCR property names which will contain the priority value. Defauls to none.
+* *priority.properties* The set of JCR property names which will contain the priority value. Defaults to none.
+
+#### Since v2.3.0
+
+* *damassets.property* The JCR property name which will contain DAM folders to include in the sitemap.
+
+* *damassets.types* MIME types allowed for DAM assets included in the sitemap.


### PR DESCRIPTION
Updated documentation of Site Map Servlet to include new properties for configuring DAM Assets to include in the sitemap.

Corresponds with pending PR https://github.com/Adobe-Consulting-Services/acs-aem-commons/pull/619