### PR TITLE
Fixed broken note link in dispatcher-ttl docs

### DIFF
--- a/_acs-aem-commons/features/dispatcher-ttl/index.md
+++ b/_acs-aem-commons/features/dispatcher-ttl/index.md
@@ -15,7 +15,7 @@ initial-release: 2.2.0
 
 Easily set TTL headers on Requests in support of [AEM Dispatcher 4.1.11](https://www.adobeaemcloud.com/content/companies/public/adobe/dispatcher/dispatcher.html) TTL support.
 
-ACS AEM Commons Dispatcher TTL allows Response Headers to be set instructing AEM Dispatcher to respect a TTL-based timeout. This feature does expect that a Dispatcher is in the request chain. To enable support in other scenarios, see the [note](acs-aem-commons/features/dispatcher-ttl.html#note).
+ACS AEM Commons Dispatcher TTL allows Response Headers to be set instructing AEM Dispatcher to respect a TTL-based timeout. This feature does expect that a Dispatcher is in the request chain. To enable support in other scenarios, see the [note](#note).
 
 The following expiration configurations are supported
 


### PR DESCRIPTION
just links to the anchor name rather than giving the full path

The note link on the https://adobe-consulting-services.github.io/acs-aem-commons/features/dispatcher-ttl/index.html page currently links to https://adobe-consulting-services.github.io/acs-aem-commons/features/dispatcher-ttl/acs-aem-commons/features/dispatcher-ttl.html#note which gives a 404