### PR TITLE
Change example annotation to Inject

### DIFF
--- a/_acs-aem-commons/features/sling-model-injectors/i18n/index.md
+++ b/_acs-aem-commons/features/sling-model-injectors/i18n/index.md
@@ -21,11 +21,11 @@ Note: Out of performance reasons, only the I18n can be injected using the generi
     @Model(adaptables = { SlingHttpServletRequest.class, Resource.class })
     public class TestModel {
 
-        @I18N
+        @Inject
         private I18n i18n;
 
         @I18N("com.adobe.i18n.backButtonText")
-        private String backButtonText
+        private String backButtonText;
         
         @PostConstruct
         public void init(){


### PR DESCRIPTION
The example did not work with `I18N` annotation in `AEM 6.5`. It does - with `Inject`.