### PR TITLE
Added leading slash to set baseurl context to the root.

### DIFF
--- a/_data/acs-aem-commons.yml
+++ b/_data/acs-aem-commons.yml
@@ -1,5 +1,5 @@
 name: acs-aem-commons
-baseurl: acs-aem-commons
+baseurl: /acs-aem-commons
 title: ACS AEM Commons
 version60: 2.14.0
 version: 4.2.0


### PR DESCRIPTION
Fixes a few broken links on the documentation site where the baseurl is used without a trailing slash, so the base url is added to the page context.  

For example, the link to the versioned clientlib page on:
https://adobe-consulting-services.github.io/acs-aem-commons/features/utils-and-apis/static-reference-rewriter/index.html

...contains the `acs-aem-commons` part twice as it is added on after the `static-reference-rewriter` section like so:
https://adobe-consulting-services.github.io/acs-aem-commons/features/utils-and-apis/static-reference-rewriter/acs-aem-commons/features/versioned-clientlibs.html

there's also a few broken images at the locations here:
https://github.com/Adobe-Consulting-Services/adobe-consulting-services.github.io/search?l=Markdown&q=site.data.acs-aem-commons.baseurl

It looks safe to change the base url rather than add the leading slashes to all of the locations, but its a little difficult to test under my own repo domain.

