### PR TITLE
Aem as a Cloud Service incompatibility banner

### DIFF
--- a/_acs-aem-commons/features/bulk-workflow-manager/index.md
+++ b/_acs-aem-commons/features/bulk-workflow-manager/index.md
@@ -5,6 +5,7 @@ description: Execute Workflow at scale!
 date: 2016-07-24
 redirect_from: /acs-aem-commons/features/bulk-workflow-manager.html
 feature-tags: administration content-migration
+tags: aemcs-incompatible
 initial-release: 2.6.4/3.2.4
 ---
 

--- a/_acs-aem-commons/features/ensure-oak-index/index.md
+++ b/_acs-aem-commons/features/ensure-oak-index/index.md
@@ -5,6 +5,7 @@ description: Include Oak Indexes in your app package
 date: 2015-10-02
 redirect_from: /acs-aem-commons/features/ensure-oak-index.html
 feature-tags: backend-dev
+tags: aemcs-incompatible
 initial-release: 2.1.0
 last-updated-release: 4.0.0
 ---

--- a/_acs-aem-commons/features/file-fetcher/index.md
+++ b/_acs-aem-commons/features/file-fetcher/index.md
@@ -5,6 +5,7 @@ description: Automatically pull files into AEM and publish them
 date: 2019-12-17
 redirect_from: /acs-aem-commons/features/mcp.html
 feature-tags: administration
+tags: aemcs-incompatible
 initial-release: 4.4.0
 ---
 

--- a/_acs-aem-commons/features/healthchecks/index.md
+++ b/_acs-aem-commons/features/healthchecks/index.md
@@ -4,6 +4,7 @@ title: Health Checks
 description: Check AEM's temperature
 date: 2017-08-08
 feature-tags: administration standard
+tags: aemcs-incompatible
 initial-release: 3.4.0
 ---
 

--- a/_acs-aem-commons/features/healthchecks/smtp/index.md
+++ b/_acs-aem-commons/features/healthchecks/smtp/index.md
@@ -5,6 +5,7 @@ description: Check AEM's temperature
 date: 2016-11-01
 redirect_from: /acs-aem-commons/features/healthchecks.html
 initial-release: 3.4.0
+tags: aemcs-incompatible
 ---
 
 > [Add health checks to your Granite WebUI](https://docs.adobe.com/docs/en/aem/6-3/administer/operations/operations-dashboard.html#Health Reports). 

--- a/_acs-aem-commons/features/healthchecks/status-emailer/index.md
+++ b/_acs-aem-commons/features/healthchecks/status-emailer/index.md
@@ -4,6 +4,7 @@ title: Health Check Status E-mailer
 description: Actually know when health checks fail!
 date: 2017-08-08
 initial-release: 2.13.0/3.10.0
+tags: aemcs-incompatible
 ---
 
 ## Purpose

--- a/_acs-aem-commons/features/json-event-logger/index.md
+++ b/_acs-aem-commons/features/json-event-logger/index.md
@@ -5,6 +5,7 @@ description: Log OSGi events as JSON
 date: 2014-07-23
 redirect_from: /acs-aem-commons/features/json-event-logger.html
 feature-tags: administration
+tags: aemcs-incompatible
 initial-release: 1.7.0
 ---
 

--- a/_acs-aem-commons/features/mcp-tools/asset-ingestion/asset-ingestor/index.md
+++ b/_acs-aem-commons/features/mcp-tools/asset-ingestion/asset-ingestor/index.md
@@ -5,6 +5,7 @@ description: Load a directory of assets into AEM
 date: 2017-11-01
 initial-release: 3.10.0
 last-updated-release: 3.16.0
+tags: aemcs-incompatible
 ---
 
 This is an example of a high-speed parallel asset ingestor utility.  You can load a directory of assets into AEM very easily with this tool.  Because of the ability to overload a server with assets, this tool only appears for the "admin" user right now.

--- a/_acs-aem-commons/features/mcp-tools/asset-ingestion/index.md
+++ b/_acs-aem-commons/features/mcp-tools/asset-ingestion/index.md
@@ -6,6 +6,7 @@ date: 2017-12-01
 feature-tags: authoring administration content-migration
 initial-release: 3.10.0
 last-updated-release: 3.17.0
+tags: aemcs-incompatible
 ---
 
 These are the [MCP](/acs-aem-commons/features/mcp/index.html) Asset Ingestion Tools provided by ACS AEM Commons available at `Tools > ACS AEM Commons > Manage Controlled Process > Start Process`.

--- a/_acs-aem-commons/features/mcp-tools/asset-ingestion/s3-asset-ingestor/index.md
+++ b/_acs-aem-commons/features/mcp-tools/asset-ingestion/s3-asset-ingestor/index.md
@@ -4,6 +4,7 @@ title: S3 Asset Ingestor
 description: Load a S3 bucket of assets into AEM
 date: 2017-11-01
 initial-release: 3.11.0
+tags: aemcs-incompatible
 ---
 
 This is essentially the same as the [File Asset Ingestor](../asset-ingestor/index.html), but pulls files from an Amazon S3 bucket instead of the local filesystem.  You can load a directory of assets into AEM very easily with this tool.  Because of the ability to overload a server with assets, this tool only appears for the "admin" user right now.

--- a/_acs-aem-commons/features/mcp-tools/asset-ingestion/url-asset-ingestor/index.md
+++ b/_acs-aem-commons/features/mcp-tools/asset-ingestion/url-asset-ingestor/index.md
@@ -6,6 +6,7 @@ date: 2018-05-04
 feature-tags: content-migration authoring administration
 initial-release: 3.15.0
 last-updated-release: 3.17.0
+tags: aemcs-incompatible
 ---
 
 This tool loads assets listed in a spreadsheet and optionally also sets additional asset metadata if provided.

--- a/_acs-aem-commons/features/mcp-tools/refresh-folder-thumbnails/index.md
+++ b/_acs-aem-commons/features/mcp-tools/refresh-folder-thumbnails/index.md
@@ -5,6 +5,7 @@ description: Fix folder thumbnails quickly!
 date: 2018-05-07
 feature-tags: authoring administration
 initial-release: 3.16.0
+tags: aemcs-incompatible
 ---
 
 This repairs invalid or missing thumbnails on asset folders (just folders, not assets) which might have become invalid for one reason or another.  [Click here](/acs-aem-commons/features/mcp/subpages/process-manager.html) to read on how to start a process.  When prompted to  select the process, pick "Refresh Folder Thumbnails."

--- a/_acs-aem-commons/features/redirect-map-manager/index.md
+++ b/_acs-aem-commons/features/redirect-map-manager/index.md
@@ -6,6 +6,7 @@ date: 2018-09-23
 feature-tags: administraton backend-dev seo
 initial-release: 3.13.0
 last-updated-release: 3.18.0
+tags: aemcs-incompatible
 ---
 
 ## Purpose

--- a/_acs-aem-commons/features/remote-assets/index.md
+++ b/_acs-aem-commons/features/remote-assets/index.md
@@ -6,6 +6,7 @@ date: 2019-03-11
 redirect_from: /acs-aem-commons/features/remote-assets.html 
 feature-tags: new beta administration authoring content-migration
 initial-release: 4.1.0
+tags: aemcs-incompatible
 ---
 
 ## Purpose

--- a/_acs-aem-commons/features/versioned-clientlibs/index.md
+++ b/_acs-aem-commons/features/versioned-clientlibs/index.md
@@ -5,7 +5,7 @@ description: Set TTLs on ClientLib JS/CSS to infinity and beyond!
 date: 2013-10-01
 redirect_from: /acs-aem-commons/features/versioned-clientlibs.html
 feature-tags: component-dev backend-dev
-tags: 
+tags: aemcs-incompatible
 initial-release: 1.2.0
 ---
 

--- a/_acs-aem-commons/features/workflow-processes/assets-rendition-matter/index.md
+++ b/_acs-aem-commons/features/workflow-processes/assets-rendition-matter/index.md
@@ -6,7 +6,7 @@ sub-feature: true
 date: 2013-10-02
 initial-release: 1.2.0
 tags: aemcs-incompatible
-
+----
 ## Purpose
 This process ensures that an rendition *exactly* matches a set of dimensions by applying a matte. This  is sometimes referred to as letterboxing (when the matte is applied on the top and bottom of the image) or windowboxing (when the matte is applied on the left and right of the Both the horizontal and the vertical position along with the dimensions can be configured via parameters.
 

--- a/_acs-aem-commons/features/workflow-processes/assets-rendition-matter/index.md
+++ b/_acs-aem-commons/features/workflow-processes/assets-rendition-matter/index.md
@@ -5,7 +5,7 @@ description: Matte your assets!
 sub-feature: true
 date: 2013-10-02
 initial-release: 1.2.0
----
+tags: aemcs-incompatible
 
 ## Purpose
 This process ensures that an rendition *exactly* matches a set of dimensions by applying a matte. This  is sometimes referred to as letterboxing (when the matte is applied on the top and bottom of the image) or windowboxing (when the matte is applied on the left and right of the Both the horizontal and the vertical position along with the dimensions can be configured via parameters.

--- a/_acs-aem-commons/features/workflow-processes/assets-watermark-process/index.md
+++ b/_acs-aem-commons/features/workflow-processes/assets-watermark-process/index.md
@@ -5,6 +5,7 @@ description: Watermark asset renditions.
 redirect_from: /acs-aem-commons/features/dam-workflow-processes.html
 date: 2013-10-02
 initial-release: 1.0.0
+tags: aemcs-incompatible
 ---
 
 ### Purpose

--- a/_acs-aem-commons/features/workflow-processes/brand-portal/index.md
+++ b/_acs-aem-commons/features/workflow-processes/brand-portal/index.md
@@ -5,7 +5,7 @@ description: Sync AEM assets with Brand Portal from AEM Workflow
 sub-feature: true
 date: 2017-08-13
 initial-release: 3.10.0
-tags: new
+tags: new aemcs-incompatible
 ---
 
 ## Purpose

--- a/_includes/acs-aem-commons/aemcs-incompatible.html
+++ b/_includes/acs-aem-commons/aemcs-incompatible.html
@@ -1,0 +1,8 @@
+<div class="aemcs-incompatible">
+    <div class="aemcs-incompatible__title">AEM as a Cloud Service incompatible!</div>
+    <p>
+        This feature is <em>not</em> AEM as a Cloud Service compatible.
+        <br/>
+        Even if it <em>appears</em> to work on AEM as a Cloud Service, please do not use it, <em>as it will cause problems!!!</em>
+    </p>
+</div>

--- a/_layouts/acs-aem-commons_feature.html
+++ b/_layouts/acs-aem-commons_feature.html
@@ -37,6 +37,11 @@ layout: acs-aem-commons_default
                 {% endif %}
             </div>
 
+
+            {% if page.tags contains 'aemcs-incompatible' %}
+            {% include acs-aem-commons/aemcs-incompatible.html %}
+            {% endif %}
+
             {{ content }}
 
             {% include acs-aem-commons/comments.html %}

--- a/_sass/_feature-docs.scss
+++ b/_sass/_feature-docs.scss
@@ -167,3 +167,16 @@ pre {
       }
 
 }
+.aemcs-incompatible {
+    background-color: lighten(orange, 10%);
+    padding: 2rem 1rem; 
+    border-radius: 3px;
+    text-align: center;
+    font-weight: 200;
+    
+    .aemcs-incompatible__title {
+      font-size: 2.5rem;
+      padding-bottom: 1rem;
+    }
+    
+}


### PR DESCRIPTION
Adds a banner to the feature docs for ACS Commons if frontmatter has

`tags: aemcs-incompatible`

Took a first pass at tagging obvious candidates.

![image](https://user-images.githubusercontent.com/1451868/74381943-74f9b880-4dba-11ea-9efb-ba503668e9d1.png)
