### PR TITLE
Extensionless URLs Format Fix

### DIFF
--- a/_acs-aem-commons/features/sitemap/index.md
+++ b/_acs-aem-commons/features/sitemap/index.md
@@ -37,7 +37,7 @@ Typically, you will also want to use either Resource Resolver Mappings or mod_re
     jcr:primaryType="sling:OsgiConfig"
     sling.servlet.resourceTypes="[myapp/components/page/home-page]"
     externalizer.domain="publish"
-    extensionless.urls="Boolean{true}"
+    extensionless.urls="{Boolean}true"
     include.lastmod="{Boolean}false"
     changefreq.properties="[myChangeFreqProperties]"
     priority.properties="[myPriorityProperties]"


### PR DESCRIPTION
Relatively straightforward change.  In the OSIG config example, the value for extensionless urls is incorrect and won't work.  Just fixing that to make it easier to use.