### PR TITLE
fixing frontmatter delimiter for WF Process Doc Pages

### DIFF
--- a/_acs-aem-commons/features/workflow-processes/assets-rendition-matter/index.md
+++ b/_acs-aem-commons/features/workflow-processes/assets-rendition-matter/index.md
@@ -6,7 +6,7 @@ sub-feature: true
 date: 2013-10-02
 initial-release: 1.2.0
 tags: aemcs-incompatible
-----
+---
 
 ## Purpose
 This process ensures that an rendition *exactly* matches a set of dimensions by applying a matte. This  is sometimes referred to as letterboxing (when the matte is applied on the top and bottom of the image) or windowboxing (when the matte is applied on the left and right of the Both the horizontal and the vertical position along with the dimensions can be configured via parameters.


### PR DESCRIPTION
The wf process index page link to the rendition matter process, and the page for that process, are both broken

https://adobe-consulting-services.github.io/acs-aem-commons/features/workflow-processes/index.html
https://adobe-consulting-services.github.io/acs-aem-commons/features/workflow-processes/assets-rendition-matter/index.html

For whatever reason, at least for me, they seem to render fine with Jekyll locally. Either way, it looks like there was just an extra `-` on the end front-matter delimiter. I've removed that to try to correct it.