### PR TITLE
ACS -> AEM Community Software

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-name: Adobe Consulting Services
+name: Adobe Community Software
 highlighter: rouge
 markdown: kramdown
 exclude:  [ Gemfile, Gemfile.lock, README.md, vendor/, .idea/]

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-name: Adobe Community Software
+name: AEM Community Software
 highlighter: rouge
 markdown: kramdown
 exclude:  [ Gemfile, Gemfile.lock, README.md, vendor/, .idea/]

--- a/_includes/acs-aem-projects/nav.html
+++ b/_includes/acs-aem-projects/nav.html
@@ -1,5 +1,5 @@
 <ul class="nav">
-    <li class="first"><a href="/index.html">Adobe Community Software</a></li>
+    <li class="first"><a href="/index.html">AEM Community Software</a></li>
     <li><a href="/acs-aem-commons">ACS AEM Commons</a></li>
     <li><a href="/acs-aem-tools">ACS AEM Tools</a></li>
     <li><a href="/acs-aem-samples">ACS AEM Samples</a></li>	

--- a/_includes/acs-aem-projects/nav.html
+++ b/_includes/acs-aem-projects/nav.html
@@ -1,5 +1,5 @@
 <ul class="nav">
-    <li class="first"><a href="/index.html">Adobe Consulting Services</a></li>
+    <li class="first"><a href="/index.html">Adobe Community Software</a></li>
     <li><a href="/acs-aem-commons">ACS AEM Commons</a></li>
     <li><a href="/acs-aem-tools">ACS AEM Tools</a></li>
     <li><a href="/acs-aem-samples">ACS AEM Samples</a></li>	

--- a/_includes/shared/who-we-are.html
+++ b/_includes/shared/who-we-are.html
@@ -4,8 +4,7 @@
         <h4>Who we are</h4>
 
         <p>
-            We are the AEM developer community.
-            We are developers that like AEM, and like building solutions on top of Adobe products including Adobe Experience Manager (AEM, fka CQ, fka Communique).        
+            We are developers that build things for Adobe products including Adobe Experience Manager (AEM, fka CQ, fka Communique).        
         </p>
 
         <p>

--- a/_includes/shared/who-we-are.html
+++ b/_includes/shared/who-we-are.html
@@ -4,9 +4,12 @@
         <h4>Who we are</h4>
 
         <p>
-            We are Adobe Consulting Services.
-            We build solutions on top of Adobe products including Adobe Experience Manager (AEM, fka CQ, fka Communique).
-            <a href="http://www.adobe.com/consulting/" target="_blank">Learn more.</a>
+            We are the AEM developer community.
+            We are developers that like AEM, and like building solutions on top of Adobe products including Adobe Experience Manager (AEM, fka CQ, fka Communique).        
+        </p>
+
+        <p>
+            Please note that the name of this Github organization and repository are from a legacy ownership of the this project. Adobe Consulting Services is no longer maintains this project, instead the AEM developer community does.
         </p>
     </div>
 </section>

--- a/_includes/shared/who-we-are.html
+++ b/_includes/shared/who-we-are.html
@@ -9,7 +9,8 @@
         </p>
 
         <p>
-            Please note that the name of this Github organization and repository are from a legacy ownership of the this project. Adobe Consulting Services is no longer maintains this project, instead the AEM developer community does.
+            Please note that the name of this Github organization and repository are from a legacy ownership of the this project. 
+            Adobe Consulting Services no longer maintains this project, rather the AEM developer community does.
         </p>
     </div>
 </section>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 ---
 layout: acs-aem-projects_home
-title: Adobe Consulting Services
+title: Adobe Community Software
 description: A collection of AEM works aimed at enabling the deployment and development of AEM-based solutions.
 ---
 

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 ---
 layout: acs-aem-projects_home
-title: Adobe Community Software
+title: AEM Community Software
 description: A collection of AEM works aimed at enabling the deployment and development of AEM-based solutions.
 ---
 


### PR DESCRIPTION
There have been numerous instances of folks misunderstanding Adobe Consulting Services' involvement in/ownership of the ACS AEM Commons project. 

The genesis of the project did primarily see contributions from Adobe Consulting Services however as the project has evolved, the bulk of activity and contributions are from non-Adobe Consulting Services people. 

To help alleviate confusion, what do we think about a "technical" rebranding to Adobe Community Sofware - we can keep the ACS acronym, but separate from the Adobe Consulting Services brand.

Ideally we'd also change the Github repo name, and also any mentions in the code base (pom.xml, readmes)