### PR TITLE
fix broken links and typos in redirect manager docs

### DIFF
--- a/_acs-aem-commons/features/redirect-manager/advanced.md
+++ b/_acs-aem-commons/features/redirect-manager/advanced.md
@@ -12,7 +12,7 @@ The `additionalHeaders` parameter specifies additional response headers to apply
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
           jcr:primaryType="sling:OsgiConfig"
-          enabed="{Boolean}true"
+          enabled="{Boolean}true"
           additionalHeaders="[Cache-Control: max-age=3600,Cache-Control: no-store]"
 />
 ```
@@ -41,7 +41,7 @@ The default value is `true`. Set `preserveQueryString` to false to drop query st
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
           jcr:primaryType="sling:OsgiConfig"
-          enabed="{Boolean}true"
+          enabled="{Boolean}true"
           preserveQueryString="{Boolean}false"
 />
 ```

--- a/_acs-aem-commons/features/redirect-manager/index.md
+++ b/_acs-aem-commons/features/redirect-manager/index.md
@@ -40,7 +40,7 @@ To enable redirects create a configuration for PID `com.adobe.acs.commons.redire
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
           jcr:primaryType="sling:OsgiConfig"
-          enabed="{Boolean}true"/>
+          enabled="{Boolean}true"/>
 ```
 
 ###  Create Redirects

--- a/_acs-aem-commons/features/redirect-manager/index.md
+++ b/_acs-aem-commons/features/redirect-manager/index.md
@@ -52,7 +52,7 @@ You will see a list of available redirect configurations. The default global con
 automatically by ACS Commons and it is a good start to put your redirects.
 
 ![/conf/global](images/conf_global.png)
-See [Context Aware Configuration](./caconfig.md) how to maintain different redirect configuration per context
+See [Context Aware Configuration](./caconfig.html) how to maintain different redirect configuration per context
 
 Click on `/conf/global` to start managing redirect configurations
 
@@ -70,7 +70,7 @@ Redirects are supported for pages and assets. You can match by exact path or by 
 Target can include back-references ($N) to the regex pattern which will be replaced by the contents of the Nth group of
 the regex match.
 
-See [Manage Redirects](./manage.md) for more information.
+See [Manage Redirects](./manage.html) for more information.
 
 ### Replicate 
 

--- a/_acs-aem-commons/features/redirect-manager/manage.md
+++ b/_acs-aem-commons/features/redirect-manager/manage.md
@@ -27,7 +27,7 @@ the regex match.
 
 Redirect target can be a full JCR path ( `/content/we-retail/en/about` ) or a shortened path (`/en/about`) compatible with 
 your Dispatcher mod_rewrite rules or an external url (https://www.we-retail.com/en/about). 
-You can use [Sling Mappings](./mappings.md) or a [custom class](./mappings.md#custom-location-rewriter) to rewrite Location header.
+You can use [Sling Mappings](./mappings.html) or a [custom class](./mappings.html#custom-location-rewriter) to rewrite Location header.
 
 ### Examples:
 

--- a/_acs-aem-commons/features/redirect-manager/mappings.md
+++ b/_acs-aem-commons/features/redirect-manager/mappings.md
@@ -39,7 +39,7 @@ or add a `rewriteUrls="{Boolean}true"` parameter in the OSGi configuration:
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
           jcr:primaryType="sling:OsgiConfig"
           rewriteUrls="{Boolean}true"
-          enabed="{Boolean}true"/>
+          enabled="{Boolean}true"/>
 ```
 
 ### Example


### PR DESCRIPTION
a few links were ending with .md which resulted in a 404. The PR changes these to .html.