### PR TITLE
docs: Fix JCRNodeChangeEventHandler config path

### DIFF
--- a/_acs-aem-commons/features/http-cache/subpages/invalidation.md
+++ b/_acs-aem-commons/features/http-cache/subpages/invalidation.md
@@ -20,7 +20,7 @@ Custom cache invalidation events could be sling event handlers for JCR specific 
 
 Sample cache invalidation job creator. Watches for changes in JCR nodes and creates sling jobs for cache invalidation.  
 
-Define a `sling:OsgiConfig` `/apps/mysite/config/com.adobe.acs.commons.httpcache.store.mem.impl.JCRNodeChangeEventHandler.xml`
+Define a `sling:OsgiConfig` `/apps/mysite/config/com.adobe.acs.commons.httpcache.invalidator.event.JCRNodeChangeEventHandler.xml`
 
 {% highlight xml %}
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
1. There is an HTTP Cache feature in the ACS AEM Commons Library (https://adobe-consulting-services.github.io/acs-aem-commons/features/http-cache/index.html).

2. HTTP Cache feature provides a configurable `JCRNodeChangeEventHandler` OSGi component.

3. Fully-qualified class name (FQCN) of `JCRNodeChangeEventHandler` is `com.adobe.acs.commons.httpcache.invalidator.event.JCRNodeChangeEventHandler` (https://github.com/Adobe-Consulting-Services/acs-aem-commons/blob/master/bundle/src/main/java/com/adobe/acs/commons/httpcache/invalidator/event/JCRNodeChangeEventHandler.java). Therefore, OSGi configuration for the component should have in its name the mentioned FQCN incorporated.
 
4. According to the current documentation being changed within this pull request, OSGi configuration for `JCRNodeChangeEventHandler` should have in its name the following FQCN incorporated: `com.adobe.acs.commons.httpcache.store.mem.impl.JCRNodeChangeEventHandler`. That istruction is wrong, because a class with such FQCN doesn't exist and the real FQCN for `JCRNodeChangeEventHandler` is `com.adobe.acs.commons.httpcache.invalidator.event.JCRNodeChangeEventHandler`. An OSGi configuration created according to the current version of documentation has no relevant effect and the configuration isn't recognized as a valid one for `JCRNodeChangeEventHandler`.
 
5. This pull request fixes the discrepancy described above via adjustment of the documentation so that it points at the real FQCN of `JCRNodeChangeEventHandler`, i.e. via the replacement of `com.adobe.acs.commons.httpcache.store.mem.impl.JCRNodeChangeEventHandler` with `com.adobe.acs.commons.httpcache.invalidator.event.JCRNodeChangeEventHandler`.