### PR TITLE
mark Redirect Map Manager as enabled in AEM CS

### DIFF
--- a/_acs-aem-commons/features/redirect-manager/index.md
+++ b/_acs-aem-commons/features/redirect-manager/index.md
@@ -5,7 +5,7 @@ description: Manage HTTP Redirects in AEM
 date: 2021-03-12
 tags: aem-65 aem-cs
 initial-release: 5.0.4
-last-updated-release: 5.4.0
+last-updated-release: 6.6.5
 ---
 
 ## Purpose

--- a/_acs-aem-commons/features/redirect-manager/index.md
+++ b/_acs-aem-commons/features/redirect-manager/index.md
@@ -5,7 +5,7 @@ description: Manage HTTP Redirects in AEM
 date: 2021-03-12
 tags: aem-65 aem-cs
 initial-release: 5.0.4
-last-updated-release: 6.6.5
+last-updated-release: 5.4.0
 ---
 
 ## Purpose

--- a/_acs-aem-commons/features/redirect-map-manager/index.md
+++ b/_acs-aem-commons/features/redirect-map-manager/index.md
@@ -5,7 +5,7 @@ description: Generate an Apache httpd Redirect Map from Properties in AEM
 date: 2018-09-23
 tags: aem-65 aem-cs
 initial-release: 3.13.0
-last-updated-release: 3.18.0
+last-updated-release: 6.6.6
 ---
 
 ## Purpose

--- a/_acs-aem-commons/features/redirect-map-manager/index.md
+++ b/_acs-aem-commons/features/redirect-map-manager/index.md
@@ -36,6 +36,8 @@ Once you are happy with your Redirect Map file, activate the configuration page 
 
 ### Configuring Apache
 
+#### On-premise and Adobe Managed Services
+
 Before using the Redirect Map Manager, you need to configure Apache to retrieve the file from the AEM Publisher and update it's Redirect Map DB. To set this up you should:
 
 1. Configure Apache to use a redirect map at your intended path. For example, if I wanted to use a Redirect Map DB stored at `/etc/httpd/conf/redirectmap.map`, I could add the following into my site's conf file:
@@ -71,6 +73,10 @@ Before using the Redirect Map Manager, you need to configure Apache to retrieve 
     You can get the path to your Redirect Map file from the Preview tab of the Redirect Map editor page.
 
 Once you restart Apache, this will automatically pull changes from the Redirect Map Manager every hour into Apache.
+
+#### AEM as a Cloud Service
+
+Currently please refer to Early Adopter Program functionality described in [Business users can declare redirects outside of Git (Early Adopter Program)](https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/release-notes/release-notes/2024/release-notes-2024-5-0#apache-rewritemaps-early-adopter) to opt-in.
 
 ## Redirect Map Manager Features
 

--- a/_acs-aem-commons/features/redirect-map-manager/index.md
+++ b/_acs-aem-commons/features/redirect-map-manager/index.md
@@ -3,7 +3,7 @@ layout: acs-aem-commons_feature
 title: Redirect Map Manager
 description: Generate an Apache httpd Redirect Map from Properties in AEM
 date: 2018-09-23
-tags: aem-65
+tags: aem-65 aem-cs
 initial-release: 3.13.0
 last-updated-release: 3.18.0
 ---


### PR DESCRIPTION
* Marking [Redirect Map Manager](https://adobe-consulting-services.github.io/acs-aem-commons/features/redirect-map-manager/index.html) as enabled in AEM CS as in https://github.com/Adobe-Consulting-Services/acs-aem-commons/pull/3420 should be in [next release 6.6.5](https://github.com/Adobe-Consulting-Services/acs-aem-commons/releases)
* Separating [description of Apache HTTPD side](https://adobe-consulting-services.github.io/acs-aem-commons/features/redirect-map-manager/index.html#configuring-apache) into on-prem/AMS (previous version) and AEM CS version pointing currently to [Early Adopter program description](https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/release-notes/release-notes/2024/release-notes-2024-5-0#apache-rewritemaps-early-adopter)

cc: @davidjgonzalez @SachinMali @joerghoh @chaik @froesef