### PR TITLE
updating linked AEM CS docs page with permanent one for release 18311 for Redirect Map Manager usage

### DIFF
--- a/_acs-aem-commons/features/redirect-map-manager/index.md
+++ b/_acs-aem-commons/features/redirect-map-manager/index.md
@@ -78,7 +78,7 @@ Once you restart Apache, this will automatically pull changes from the Redirect 
 
 Configuring Redirect Map Manager is described in [Pipeline-free URL Redirects](https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/implementing/content-delivery/pipeline-free-url-redirects).
 
-Please note that this functionality is available since AEM CS Release 18311 - see [Experience Manager Releases Roadmap](https://experienceleague.adobe.com/en/docs/experience-manager-release-information/aem-release-updates/update-releases-roadmap?lang=en#aem-as-cloud-service).
+Please note that this functionality is available since AEM CS Release 18311 - see [Experience Manager Releases Roadmap](https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/release-notes/maintenance/2024/2024-10-0?lang=en#18311).
 
 ## Redirect Map Manager Features
 


### PR DESCRIPTION
Updating link in documentation on [Redirect Map Manager](https://adobe-consulting-services.github.io/acs-aem-commons/features/redirect-map-manager/index.html) availability in AEM as a Cloud Service to point to permanent [AEM CS Release 18311 page](https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/release-notes/maintenance/2024/2024-10-0?lang=en#18311)

cc: @davidjgonzalez @joerghoh @SachinMali 